### PR TITLE
Exclude *.tgz in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Binary archives
+*.tgz
+*.zip


### PR DESCRIPTION
Fix `.gitignore` to exclude `rt-client-0.4.6.tgz`.

```bash
~: cd javascript/samples
~: ./download.sh
~: git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	../rt-client-0.4.6.tgz
```