### PR TITLE
Fix javascript/samples/web build

### DIFF
--- a/javascript/samples/web/package-lock.json
+++ b/javascript/samples/web/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/audioworklet": "^0.0.57",
+        "@types/node": "^22.7.4",
         "prettier": "^3.3.3",
         "typescript": "^5.2.2",
         "vite": "^5.4.8"
@@ -855,6 +856,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -1340,6 +1351,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/javascript/samples/web/package.json
+++ b/javascript/samples/web/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/audioworklet": "^0.0.57",
+    "@types/node": "^22.7.4",
     "prettier": "^3.3.3",
     "typescript": "^5.2.2",
     "vite": "^5.4.8"


### PR DESCRIPTION
Fix `javascript/samples/web` build.

```bash
~: cd javascript/samples/web
~: npm install
~: npm run build

> realtime-sample-web@0.0.0 build
> tsc && vite build

src/main.ts:122:44 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

122 function processAudioRecordingBuffer(data: Buffer) {
                                               ~~~~~~
...
```