### PR TITLE
Add instruction to download wheels

### DIFF
--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -23,8 +23,20 @@ source venv/bin/activate
 
 ### 2. Install Dependencies
 
-Once the virtual environment is activated, install the required dependencies using `pip`:
+Once the virtual environment is activated, download the latest package wheels and install the required dependencies using `pip`:
 
+#### Windows
+
+```pwsh
+pwsh .\download-wheel.ps1
+```
+#### Linux / MacOS
+
+```bash
+./download-wheel.sh
+```
+
+Next, install the dependencies:
 ```sh
 pip install -r requirements.txt
 pip install rtclient-0.4.0-py3-none-any.whl


### PR DESCRIPTION
## Purpose
Fixes https://github.com/Azure-Samples/aoai-realtime-audio-sdk/issues/11. Currently the documentation misses instructions on how to download the wheels.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
