### PR TITLE
Updating docs to be clearer on how to get the packages.

### DIFF
--- a/javascript/samples/readme.md
+++ b/javascript/samples/readme.md
@@ -6,6 +6,17 @@
 1. Node.js installation (https://nodejs.org)
 2. Environment that can run a localhost web server
 
+### Getting the library package
+
+For these samples to work, the client library package is required to be downloaded to this folder (alternatively, it can be build from source and copied here). For that we provide a couple of scripts:
+
+- [download-pkg.sh](./download-pkg.sh) for bash
+    > Note that this script requires `jq` to be installed.
+
+- [download-pkg.ps1](./download-pkg.ps1) for PowerShell
+
+These can be run by typing `./download-pkg.sh` or `pwsh ./download-pkg.ps1` respectively.
+
 ## Using the sample
 
 1. Navigate to this folder
@@ -35,6 +46,9 @@
 
 ## Code description
 
-This sample uses a custom client to simplify the usage of the realtime API. The client package is included  in this repo in the `rt-client-0.3.3.tgz` file.
+This sample uses a custom client to simplify the usage of the realtime API. The client package can be obtained by either building the [library](../standalone/) or by downloading it using the scripts provided:
+
+- [bash ](./download-pkg.sh) - Note that  this script requires `jq` to be installed.
+- [PowerShell](./download-pkg.ps1)
 
 The primary file demonstrating `/realtime` use is [src/main.ts](./src/main.ts); the first few functions demonstrate connecting to `/realtime` using the client, sending an inference configuration message, and then processing the send/receive of messages on the connection.

--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -23,18 +23,15 @@ source venv/bin/activate
 
 ### 2. Install Dependencies
 
-Once the virtual environment is activated, download the latest package wheels and install the required dependencies using `pip`:
+Once the virtual environment is activated, download the latest package wheels using the provided scripts and install the required dependencies using `pip`:
 
-#### Windows
+- [download-pkg.sh](./download-pkg.sh) for bash
+    > Note that this script requires `jq` to be installed.
 
-```pwsh
-pwsh .\download-wheel.ps1
-```
-#### Linux / MacOS
+- [download-pkg.ps1](./download-pkg.ps1) for PowerShell
 
-```bash
-./download-wheel.sh
-```
+These can be run by typing `./download-pkg.sh` or `pwsh ./download-pkg.ps1` respectively.
+
 
 Next, install the dependencies:
 ```sh


### PR DESCRIPTION
This pull request updates the documentation for downloading and installing client library packages for JavaScript and Python samples. The most important changes include adding instructions for using provided scripts to download the necessary packages.

Documentation updates:

* [`javascript/samples/readme.md`](diffhunk://#diff-a93651484bee453ae19e6f304b7f5dc28fee3b1d551fd90bab04d5be14ee79eaR9-R19): Added instructions for downloading the client library package using `download-pkg.sh` and `download-pkg.ps1` scripts.
* [`javascript/samples/readme.md`](diffhunk://#diff-a93651484bee453ae19e6f304b7f5dc28fee3b1d551fd90bab04d5be14ee79eaL38-R52): Updated the code description to include instructions for obtaining the client package by building the library or using the provided scripts.
* [`python/samples/README.md`](diffhunk://#diff-28c8291895c41372dc2a9d58f2949cd76f8e92efbbb7625eaca3b1f022b8fe64L26-L37): Updated the dependencies installation section to include instructions for downloading the latest package wheels using `download-pkg.sh` and `download-pkg.ps1` scripts.