### PR TITLE
add more supported voices in models.py

### DIFF
--- a/python/rtclient/models.py
+++ b/python/rtclient/models.py
@@ -14,7 +14,7 @@ from pydantic import (
 
 from rtclient.util.model_helpers import ModelWithDefaults
 
-Voice = Literal["alloy", "shimmer", "echo"]
+Voice = Literal["alloy", "shimmer", "echo", "ash", "ballad", "coral", "sage", "verse"]
 AudioFormat = Literal["pcm16", "g711-ulaw", "g711-alaw"]
 Modality = Literal["text", "audio"]
 


### PR DESCRIPTION
from realtime api doc: https://platform.openai.com/docs/api-reference/realtime-client-events

>The voice the model uses to respond. Supported voices are ash, ballad, coral, sage, and verse (also supported but not recommended are alloy, echo, and shimmer; these voices are less expressive). Cannot be changed once the model has responded with audio at least once.

## Purpose
add add more supported voices in Voice model in models.py


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Use the python client and use one of the newly added supported voice: [ash, ballad, coral, sage, and verse]

## What to Check
Verify that the following are valid

new voices work

## Other Information
