### PR TITLE
Adding all OpenAI supported voices to Javascript library

### DIFF
--- a/javascript/samples/web/index.html
+++ b/javascript/samples/web/index.html
@@ -49,8 +49,13 @@
               <select id="voice">
                 <option></option>
                 <option>alloy</option>
+                <option>ash</option>
+                <option>ballad</option>
+                <option>coral</option>
                 <option>echo</option>
+                <option>sage</option>
                 <option>shimmer</option>
+                <option>verse</option>
               </select>
           </div>
         </div>

--- a/javascript/samples/web/src/main.ts
+++ b/javascript/samples/web/src/main.ts
@@ -4,7 +4,7 @@
 import { Player } from "./player.ts";
 import { Recorder } from "./recorder.ts";
 import "./style.css";
-import { LowLevelRTClient, SessionUpdateMessage } from "rt-client";
+import { LowLevelRTClient, SessionUpdateMessage, Voice } from "rt-client";
 
 let realtimeStreaming: LowLevelRTClient;
 let audioRecorder: Recorder;
@@ -212,8 +212,8 @@ function getTemperature(): number {
   return parseFloat(formTemperatureField.value);
 }
 
-function getVoice(): "alloy" | "echo" | "shimmer" {
-  return formVoiceSelection.value as "alloy" | "echo" | "shimmer";
+function getVoice(): Voice {
+  return formVoiceSelection.value as Voice;
 }
 
 function makeNewTextBlock(text: string = "") {

--- a/javascript/standalone/package-lock.json
+++ b/javascript/standalone/package-lock.json
@@ -1939,9 +1939,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/javascript/standalone/src/models.ts
+++ b/javascript/standalone/src/models.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export type Voice = "alloy" | "shimmer" | "echo";
+export type Voice =
+  | "alloy"
+  | "ash"
+  | "ballad"
+  | "coral"
+  | "echo"
+  | "sage"
+  | "shimmer"
+  | "verse";
 export type AudioFormat = "pcm16" | "g711-ulaw" | "g711-alaw";
 export type Modality = "text" | "audio";
 

--- a/python/rtclient/models.py
+++ b/python/rtclient/models.py
@@ -14,7 +14,7 @@ from pydantic import (
 
 from rtclient.util.model_helpers import ModelWithDefaults
 
-Voice = Literal["alloy", "shimmer", "echo", "ash", "ballad", "coral", "sage", "verse"]
+Voice = Literal["alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse"]
 AudioFormat = Literal["pcm16", "g711-ulaw", "g711-alaw"]
 Modality = Literal["text", "audio"]
 


### PR DESCRIPTION
This pull request includes several changes to add new voice options and update related type definitions across multiple files. Additionally, it includes an update to a package dependency.

### Addition of new voice options:

* [`javascript/samples/web/index.html`](diffhunk://#diff-c67d95c89a9677c9acb9b51771e181dff58f92b7867a52bf605444e00f25524bR52-R58): Added new voice options (`ash`, `ballad`, `coral`, `sage`, `verse`) to the voice selection dropdown.
* [`javascript/standalone/src/models.ts`](diffhunk://#diff-d75f4e3bbfffb3824506ad43c5cdf11426d7646bbca4031beee2deb64e24e28dL4-R12): Updated the `Voice` type to include the new voice options (`ash`, `ballad`, `coral`, `sage`, `verse`).
* [`python/rtclient/models.py`](diffhunk://#diff-21c64497de6de15347708dfe26736b914ca6a0b95af08f3d6f1925533df7a22bL17-R17): Updated the `Voice` literal type to include the new voice options (`ash`, `ballad`, `coral`, `sage`, `verse`).

### Codebase updates:

* [`javascript/samples/web/src/main.ts`](diffhunk://#diff-488638c1386c8834aff2ba32bc0e29d930b2b25d1189c8f47dee00748a4e21f7L7-R7): Imported the `Voice` type from the `rt-client` package and updated the `getVoice` function to use this type. [[1]](diffhunk://#diff-488638c1386c8834aff2ba32bc0e29d930b2b25d1189c8f47dee00748a4e21f7L7-R7) [[2]](diffhunk://#diff-488638c1386c8834aff2ba32bc0e29d930b2b25d1189c8f47dee00748a4e21f7L215-R216)

### Dependency update:

* [`javascript/standalone/package-lock.json`](diffhunk://#diff-9cd9e065cdd49a9ad32e414158d6b19ccb03fd4b8dfa6ed701d4ca1dd41d1c6aL1942-R1944): Updated the `cross-spawn` package from version `7.0.3` to `7.0.6`.