### PR TITLE
Fixing javascript package.json config.

### DIFF
--- a/javascript/standalone/package.json
+++ b/javascript/standalone/package.json
@@ -37,6 +37,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
This pull request includes a small change to the `javascript/standalone/package.json` file. The change specifies the module type for the package.

* [`javascript/standalone/package.json`](diffhunk://#diff-85e5f48cb4531cbd5c4647fcdc90023302e52b3329e003ecf4a19a12c7697ecaR40): Added `"type": "module"` to specify the module type for the package.