### PR TITLE
[js] Fix: Making ResponseCreateParams optional params optional.

### DIFF
--- a/javascript/standalone/package-lock.json
+++ b/javascript/standalone/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rt-client",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rt-client",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"
@@ -2652,9 +2652,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {

--- a/javascript/standalone/package.json
+++ b/javascript/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "test": "vitest",
     "build": "rollup -c",

--- a/javascript/standalone/rollup.config.mjs
+++ b/javascript/standalone/rollup.config.mjs
@@ -8,7 +8,7 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import alias from "@rollup/plugin-alias";
 import replace from "@rollup/plugin-replace";
 
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 export default [
   {

--- a/javascript/standalone/src/models.ts
+++ b/javascript/standalone/src/models.ts
@@ -170,8 +170,8 @@ export interface ItemDeleteMessage extends ClientMessageBase {
 }
 
 export interface ResponseCreateParams {
-  commit: boolean;
-  cancel_previous: boolean;
+  commit?: boolean;
+  cancel_previous?: boolean;
   append_input_items?: Item[];
   input_items?: Item[];
   instructions?: string;

--- a/javascript/standalone/test/client.spec.ts
+++ b/javascript/standalone/test/client.spec.ts
@@ -232,11 +232,11 @@ describe.each([
         });
         const response = await client.generateResponse();
         expect(response).toBeDefined();
-        expect(response.id).toBeDefined();
-        expect(response.id!.length).toBeGreaterThan(0);
-        for await (const item of response) {
+        expect(response!.id).toBeDefined();
+        expect(response!.id!.length).toBeGreaterThan(0);
+        for await (const item of response!) {
           expect(item).toBeDefined();
-          expect(item.responseId).toBe(response.id);
+          expect(item.responseId).toBe(response!.id);
           expect(item.previousItemId).toBe(sentItem.id);
         }
       });
@@ -254,14 +254,15 @@ describe.each([
           ],
         });
         const response = await client.generateResponse();
-        await response.cancel();
+        expect(response).toBeDefined();
+        await response!.cancel();
 
         let itemCount = 0;
-        for await (const _item of response) {
+        for await (const _item of response!) {
           itemCount++;
         }
         expect(itemCount).toBe(0);
-        expect(["cancelled", "completed"].includes(response.status));
+        expect(["cancelled", "completed"].includes(response!.status));
       });
 
       it("items should properly be emitted for text in text out", async () => {
@@ -277,8 +278,9 @@ describe.each([
           ],
         });
         const response = await client.generateResponse();
+        expect(response).toBeDefined();
 
-        for await (const item of response) {
+        for await (const item of response!) {
           expect(item.type).toBe("message");
           assert(item.type === "message");
           for await (const part of item) {
@@ -309,8 +311,9 @@ describe.each([
           ],
         });
         const response = await client.generateResponse();
+        expect(response).toBeDefined();
 
-        for await (const item of response) {
+        for await (const item of response!) {
           expect(item.type).toBe("message");
           assert(item.type === "message");
           for await (const part of item) {
@@ -366,8 +369,9 @@ describe.each([
             ],
           });
           const response = await client.generateResponse();
+          expect(response).toBeDefined();
 
-          for await (const item of response) {
+          for await (const item of response!) {
             expect(item.type).toBe("function_call");
             assert(item.type === "function_call");
             expect(item.functionName).toBe("get_weather_by_location");
@@ -398,8 +402,9 @@ describe.each([
             ],
           });
           const response = await client.generateResponse();
+          expect(response).toBeDefined();
 
-          for await (const item of response) {
+          for await (const item of response!) {
             expect(item.type).toBe("function_call");
             assert(item.type === "function_call");
             expect(item.functionName).toBe("get_weather_by_location");
@@ -430,8 +435,9 @@ describe.each([
             ],
           });
           const response = await client.generateResponse();
+          expect(response).toBeDefined();
 
-          for await (const item of response) {
+          for await (const item of response!) {
             expect(item.type).toBe("function_call");
             assert(item.type === "function_call");
             expect(item.functionName).toBe("get_weather_by_location");
@@ -462,8 +468,9 @@ describe.each([
             ],
           });
           const response = await client.generateResponse();
+          expect(response).toBeDefined();
 
-          for await (const item of response) {
+          for await (const item of response!) {
             expect(item.type).toBe("function_call");
             assert(item.type === "function_call");
             expect(item.functionName).toBe("get_weather_by_location");


### PR DESCRIPTION
This pull request includes several updates to the `rt-client` package, focusing on version upgrades, configuration adjustments, and improvements to test robustness.

Version upgrades and dependency updates:

* [`javascript/standalone/package-lock.json`](diffhunk://#diff-9cd9e065cdd49a9ad32e414158d6b19ccb03fd4b8dfa6ed701d4ca1dd41d1c6aL3-R9): Updated the package version from `0.5.0` to `0.5.2` and upgraded `nanoid` from `3.3.7` to `3.3.8`. [[1]](diffhunk://#diff-9cd9e065cdd49a9ad32e414158d6b19ccb03fd4b8dfa6ed701d4ca1dd41d1c6aL3-R9) [[2]](diffhunk://#diff-9cd9e065cdd49a9ad32e414158d6b19ccb03fd4b8dfa6ed701d4ca1dd41d1c6aL2655-R2657)
* [`javascript/standalone/package.json`](diffhunk://#diff-85e5f48cb4531cbd5c4647fcdc90023302e52b3329e003ecf4a19a12c7697ecaL3-R3): Updated the package version from `0.5.1` to `0.5.2`.

Configuration adjustments:

* [`javascript/standalone/rollup.config.mjs`](diffhunk://#diff-a17e5a6a2c41c416e5ecf76f76e34a9e482c660a3176bfb1a1cd8fd952f375bdL11-R11): Changed the import assertion syntax from `assert { type: "json" }` to `with { type: "json" }`.

Code improvements:

* [`javascript/standalone/src/models.ts`](diffhunk://#diff-d75f4e3bbfffb3824506ad43c5cdf11426d7646bbca4031beee2deb64e24e28dL173-R174): Made `commit` and `cancel_previous` properties optional in the `ResponseCreateParams` interface.

Test robustness improvements:

* [`javascript/standalone/test/client.spec.ts`](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9L235-R239): Added `expect(response).toBeDefined();` and used non-null assertion operator (`!`) to ensure the response is defined before accessing its properties. [[1]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9L235-R239) [[2]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9L257-R265) [[3]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9R281-R283) [[4]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9R314-R316) [[5]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9R372-R374) [[6]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9R405-R407) [[7]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9R438-R440) [[8]](diffhunk://#diff-6e2d1d9cca647c7eed290c2ae19f8d9a191e14299df87a675d02c1633311d8d9R471-R473)