### PR TITLE
Fix Python FastAPI middle tier demo for Azure backend

### DIFF
--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -1,23 +1,25 @@
+import asyncio
+import json
+import os
+import uuid
+from typing import Literal, TypedDict, Union
+
+import uvicorn
+from azure.core.credentials import AzureKeyCredential
+from azure.identity import DefaultAzureCredential
+from dotenv import load_dotenv
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.websockets import WebSocketState
-import uvicorn
-import uuid
-import json
-from typing import Union, Literal, TypedDict
-import asyncio
 from loguru import logger
-import os
-from dotenv import load_dotenv
-from azure.identity import DefaultAzureCredential
-from azure.core.credentials import AzureKeyCredential
 from rtclient import (
     InputAudioTranscription,
+    RTAudioContent,
     RTClient,
-    ServerVAD,
     RTInputAudioItem,
     RTResponse,
-    RTAudioContent,
+    ServerVAD,
+    UserMessageItem,
 )
 
 load_dotenv()
@@ -71,11 +73,20 @@ class RTSession:
         self.logger.debug(f"Initializing RT client with backend: {backend}")
 
         if backend == "azure":
-            return RTClient(
-                url=os.getenv("AZURE_OPENAI_ENDPOINT"),
-                token_credential=DefaultAzureCredential(),
-                deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
-            )
+            azure_openai_api_key = os.getenv("AZURE_OPENAI_API_KEY")
+            # If the Azure OpenAI API key is not provided, use the DefaultAzureCredential
+            if not azure_openai_api_key:
+                return RTClient(
+                    url=os.getenv("AZURE_OPENAI_ENDPOINT"),
+                    token_credential=DefaultAzureCredential(),
+                    azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+                )
+            else:
+                return RTClient(
+                    url=os.getenv("AZURE_OPENAI_ENDPOINT"),
+                    key_credential=AzureKeyCredential(azure_openai_api_key),
+                    azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+                )
         return RTClient(
             key_credential=AzureKeyCredential(os.getenv("OPENAI_API_KEY")),
             model=os.getenv("OPENAI_MODEL"),
@@ -91,7 +102,7 @@ class RTSession:
         self.logger.debug("Configuring realtime session")
         await self.client.configure(
             modalities={"text", "audio"},
-            voice="coral",
+            voice="alloy",
             input_audio_format="pcm16",
             input_audio_transcription=InputAudioTranscription(model="whisper-1"),
             turn_detection=ServerVAD(),
@@ -120,11 +131,9 @@ class RTSession:
 
             if parsed["type"] == "user_message":
                 await self.client.send_item(
-                    {
-                        "type": "message",
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": parsed["text"]}],
-                    }
+                    UserMessageItem(
+                        content=[{"type": "input_text", "text": parsed["text"]}],
+                    )
                 )
                 await self.client.generate_response()
                 self.logger.debug("User message processed successfully")


### PR DESCRIPTION
## Purpose
1. The original code force people to use Azure CLI to login, this PR add another option (using the API Key generated from Azure Portal)
2. The client.send_item expects the message to have an id attribute because it expects an Item type, so the current demo will raise an exception when user try to send a text message. Updating to UserMessageItem type has default id=None attribute.
3. Change the default voice to alloy, because coral voice also trigger a runtime exception.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Setup and start the backend under: samples/middle-tier/python-fastapi
* Setup and start the frontend under: samples/middle-tier/generic-frontend
* Send a text message for a response.


## Other Information
I found another issue (not fixed by this PR): the `RTClient.generate_response` conflicts with `RTClient.events`, because both will take the `response.created` event. As a result
- `RTClient.generate_response` will be blocked forever, because `response.created` is removed by `RTClient.events`
- In the demo here, we cannot send text messages more than once, because the first text message will block the process.

I am creating another issue for this.