### PR TITLE
Fix two critical issues with the RTClient when using Azure OpenAI in Python sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Mono auto generated files
 mono_crash.*
 
+# Pycharm
+.idea
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/samples/middle-tier/python-fastapi/README.md
+++ b/samples/middle-tier/python-fastapi/README.md
@@ -11,7 +11,7 @@ The service establishes a WebSocket server that communicates with clients using 
 - **Simplified Protocol**: Uses a custom, lightweight communication protocol.
 - **Backend Support**: Works with both Azure OpenAI and OpenAI Realtime APIs.
 - **Extendable**: Easily extend the protocol to cover additional functionalities.
-- **Secure Authentication**: For Azure, utilizes token credentials through `DefaultAzureCredential`.
+- **Secure Authentication**: For Azure, uses API key authentication through `AzureKeyCredential`.
 - **Async Implementation**: Leverages FastAPI's async capabilities for efficient WebSocket handling.
 - **Type Safety**: Utilizes Python type hints throughout the codebase.
 
@@ -27,14 +27,15 @@ Set the following environment variables in a `.env` file at the root of the proj
 ### Using Azure OpenAI Backend
 
 - `AZURE_OPENAI_ENDPOINT`: Your Azure OpenAI endpoint URL.
+- `AZURE_OPENAI_API_KEY`: Your Azure OpenAI API key.
 - `AZURE_OPENAI_DEPLOYMENT`: The name of your Azure OpenAI deployment.
 
-Authentication is handled via `DefaultAzureCredential`, supporting environment-based credentials, managed identities, or Azure CLI authentication.
+Authentication is done via API key authentication using `AzureKeyCredential`. This provides a more reliable and straightforward approach.
 
 ### Using OpenAI Realtime API Backend
 
 - `OPENAI_API_KEY`: Your OpenAI API key.
-- `OPENAI_MODEL`: The model to use (e.g., `gpt-3.5-turbo`).
+- `OPENAI_MODEL`: The model to use (e.g., `gpt-4o-realtime-preview`).
 
 ## Setup and Run
 
@@ -113,6 +114,6 @@ class ControlMessage(TypedDict):
 ## Notes
 
 - Ensure that the required environment variables are set correctly for your chosen backend.
-- For Azure backend, authentication relies on DefaultAzureCredential, so configure your environment for token-based authentication.
+- For Azure backend, authentication uses the API key method with `AzureKeyCredential`.
 - Logging is configured using Loguru and can be adjusted through its configuration.
 - The server implements CORS middleware with permissive settings for development. Adjust these settings for production use.

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -73,12 +73,12 @@ class RTSession:
         if backend == "azure":
             return RTClient(
                 url=os.getenv("AZURE_OPENAI_ENDPOINT"),
-                token_credential=DefaultAzureCredential(),
-                deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+                key_credential=AzureKeyCredential(os.getenv("AZURE_OPENAI_API_KEY")),
+                azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
             )
         return RTClient(
             key_credential=AzureKeyCredential(os.getenv("OPENAI_API_KEY")),
-            model=os.getenv("OPENAI_MODEL"),
+            model=os.getenv("OPENAI_MODEL", "gpt-4o-realtime-preview"),
         )
 
     async def send(self, message: WSMessage):


### PR DESCRIPTION
## Purpose
* Fix two critical issues with the RTClient when using Azure OpenAI:
  1. Parameter name mismatch: The sample code incorrectly uses `deployment` whereas the actual RTClient implementation expects `azure_deployment`
  2. Authentication issues: The sample code suggests using `DefaultAzureCredential()` directly with RTClient, but this fails due to type mismatches and authentication errors

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:

## How to Test
*  Get the code
git clone https://github.com/Azure-Samples/aoai-realtime-audio-sdk.git
cd aoai-realtime-audio-sdk
git checkout fix-azure-authentication
pip install -e .

* Test the code
# Set up environment variables
export AZURE_OPENAI_ENDPOINT="your_endpoint"
export AZURE_OPENAI_API_KEY="your_api_key"
export AZURE_OPENAI_DEPLOYMENT="your_deployment_name"

# Run the sample code that uses RTClient with Azure
# The exact testing steps will depend on the samples in the repository

## What to Check
Verify that the following are valid
* The sample code now correctly uses `azure_deployment` instead of `deployment`
* Authentication with Azure OpenAI works correctly using the API key method
* Documentation correctly explains authentication options

Finding the Files to Change
To help you locate the files that need modification, try:
```bash
grep -r "token_credential=DefaultAzureCredential()" .
grep -r "deployment=" .
```
## Other Information
After extensive testing, we found that using token-based authentication with DefaultAzureCredential was problematic:
1. It requires implementation of an AsyncTokenCredentialAdapter because RTClient expects an async credential
2. Even with the adapter, we continuously received 401 Unauthorized errors
3. Using API key authentication with AzureKeyCredential resolves these issues and provides a simpler approach

We attempted various solutions:
- Created adapters for DefaultAzureCredential
- Tried running sync methods in async executors
- Tested different token acquisition approaches

The simplest and most reliable solution is using API key authentication as shown in our changes.