### PR TITLE
feat(inputTranscription): add support for gpt-4o-transcribe & gpt-4o-mini-transcribe models, plus language & prompt parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ An example `session.update` that configures several aspects of the session, incl
     "instructions": "Call provided tools if appropriate for the user's input.",
     "input_audio_format": "pcm16",
     "input_audio_transcription": {
-      "model": "whisper-1"
+      "model": "whisper-1",  // We can also choose from "gpt-4o-mini-transcribe" or "gpt-4o-transcribe"
+      "language": "en", // optional language (ISO-639-1 format)
+      "prompt":"words you can expect in the input" // optional
     },
     "turn_detection": {
       "threshold": 0.4,

--- a/javascript/standalone/src/models.ts
+++ b/javascript/standalone/src/models.ts
@@ -36,7 +36,9 @@ export type ToolChoice = "auto" | "none" | "required" | FunctionToolChoice;
 export type MessageRole = "system" | "assistant" | "user";
 
 export interface InputAudioTranscription {
-  model: "whisper-1";
+  model: "whisper-1" | "gpt-4o-mini-transcribe" | "gpt-4o-transcribe";
+  language?: string;
+  prompt?: string;
 }
 
 export interface ClientMessageBase {

--- a/python/rtclient/models.py
+++ b/python/rtclient/models.py
@@ -44,7 +44,9 @@ MessageRole = Literal["system", "assistant", "user"]
 
 
 class InputAudioTranscription(BaseModel):
-    model: Literal["whisper-1"]
+    model: Literal["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"]
+    language: Optional[str] = None
+    prompt: Optional[str] = None
 
 
 class ClientMessageBase(ModelWithDefaults):


### PR DESCRIPTION
## Purpose
* Added support for the new transcription models: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe`
* Introduced optional `language` (ISO-639-1 format) and `prompt` parameters to the `InputAudioTranscription` interface
* Applied changes in both **JavaScript** and **Python** SDKs
* Updated the core library files and demonstrated usage in `client_test` under `rtclient`

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

### For JavaScript

* Get the code
  ```bash
  git clone https://github.com/Azure-Samples/aoai-realtime-audio-sdk.git
  cd aoai-realtime-audio-sdk
  cd javascript
  git checkout Added_Model_Support
  npm install
  ```

* Run tests

* Manually test usage with the updated `inputTranscription` settings under the standalone/test/client.spec.ts line 120:

  ```js
  input_audio_transcription: {
           model:"gpt-4o-transcribe",
           language="en",
           prompt="expect words related to technology"
          },
  };
  ```

### For Python

* Get the code

  ```bash
  git clone https://github.com/Azure-Samples/aoai-realtime-audio-sdk.git
  cd aoai-realtime-audio-sdk
  cd python
  cd samples
  git checkout Added_Model_Support
  pip3 install -r requirements.txt
  cd ..
  ```

* Test using `client_test` under `rtclient`:

  * Update the test snippet:

    ```python
    input_audio_transcription = InputAudioTranscription(
        model="gpt-4o-transcribe",
        language="en",
        prompt="expect words related to technology"
    )
    ```
  * Try with different model values:

    * `"whisper-1"`
    * `"gpt-4o-mini-transcribe"`
    * `"gpt-4o-transcribe"`

## What to Check

Verify that the following are valid:

* `InputAudioTranscription` in both Python and JavaScript accepts `model`, `language`, and `prompt`
* All new values (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`) are allowed and passed correctly
* Prompt format is respected based on the model:

  * Whisper: comma-separated keywords
  * GPT-4o models: free-text
* No regressions in existing behavior when using only `whisper-1`
* Functional parity between Python and JavaScript implementations

## Other Information

* The updates are backward compatible
* Comments and type hints added where applicable
* Example test cases show use with different model values and prompt formats
* Enables developers to take advantage of OpenAI’s latest audio transcription capabilities across SDKs