### PR TITLE
feat(inputAudio): Add support for noise reduction settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ One of the key session-wide settings is `turn_detection`, which controls how dat
 - `server_vad` will evaluate incoming user audio (as sent via `input_audio_buffer.append`) using a voice activity detector (VAD) component and automatically use that audio to initiate response generation on applicable conversations when an end of speech is detected. Silence detection for the VAD can be configured when specifying `server_vad` detection mode.
 - `none` will rely on caller-initiated `input_audio_buffer.commit` and `response.create` commands to progress conversations and produce output. This is useful for push-to-talk applications or situations that have external audio flow control (such as caller-side VAD component). Note that these manual signals can be still be used in `server_vad` mode to supplement VAD-initiated response generation.
 
-Transcription of user input audio is opted into via the `input_audio_transcription` property; specifying a transcription model (`whisper-1`) in this configuration will enable the delivery of `conversation.item.audio_transcription.completed` events.
+Transcription of user input audio is opted into via the `input_audio_transcription` property; specifying a transcription model (`whisper-1` or `gpt-4o-mini-transcribe` or `gpt-4o-transcribe` ) in this configuration will enable the delivery of `conversation.item.audio_transcription.completed` events.
+
+Additionally, noise reduction can be configured using the `input_audio_noise_reduction` property. Specify the type of noise reduction using the `type` field:
+- Use `near_field` for close-talking microphones such as headphones.
+- Use `far_field` for far-field microphones such as laptop or conference room microphones.
 
 An example `session.update` that configures several aspects of the session, including tools, follows. Note that all session parameters are optional; not everything needs to be configured!
 
@@ -114,6 +118,7 @@ An example `session.update` that configures several aspects of the session, incl
       "silence_duration_ms": 600,
       "type": "server_vad"
     },
+    "input_audio_noise_reduction": "near_field",
     "tools": [
       {
         "type": "function",

--- a/javascript/standalone/src/models.ts
+++ b/javascript/standalone/src/models.ts
@@ -38,7 +38,9 @@ export type MessageRole = "system" | "assistant" | "user";
 export interface InputAudioTranscription {
   model: "whisper-1";
 }
-
+export interface NoiseReduction{
+  type: "none" | "near_field" | "far_field";
+}
 export interface ClientMessageBase {
   event_id?: string;
 }
@@ -58,6 +60,7 @@ export interface SessionUpdateParams {
   tool_choice?: ToolChoice;
   temperature?: number;
   max_response_output_tokens?: number;
+  input_audio_noise_reduction?: NoiseReduction;
 }
 
 export interface SessionUpdateMessage extends ClientMessageBase {
@@ -182,6 +185,7 @@ export interface ResponseCreateParams {
   tools?: ToolsDefinition;
   tool_choice?: ToolChoice;
   output_audio_format?: AudioFormat;
+  input_audio_noise_reduction?: NoiseReduction;
 }
 
 export interface ResponseCreateMessage extends ClientMessageBase {
@@ -224,6 +228,7 @@ export interface Session {
   tool_choice: ToolChoice;
   temperature: number;
   max_response_output_tokens?: number;
+  input_audio_noise_reduction?: NoiseReduction;
 }
 
 export interface SessionCreatedMessage extends ServerMessageBase {

--- a/python/rtclient/models.py
+++ b/python/rtclient/models.py
@@ -17,7 +17,7 @@ from rtclient.util.model_helpers import ModelWithDefaults
 Voice = Literal["alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse"]
 AudioFormat = Literal["pcm16", "g711-ulaw", "g711-alaw"]
 Modality = Literal["text", "audio"]
-
+NoiseReduction = Literal["none", "near-field", "far_field"]
 
 class NoTurnDetection(ModelWithDefaults):
     type: Literal["none"] = "none"
@@ -71,7 +71,7 @@ class SessionUpdateParams(BaseModel):
     tool_choice: Optional[ToolChoice] = None
     temperature: Optional[Temperature] = None
     max_response_output_tokens: Optional[MaxTokensType] = None
-
+    input_audio_noise_reduction: Optional[NoiseReduction] = None
 
 class SessionUpdateMessage(ClientMessageBase):
     """
@@ -226,7 +226,7 @@ class ResponseCreateParams(BaseModel):
     tools: Optional[ToolsDefinition] = None
     tool_choice: Optional[ToolChoice] = None
     output_audio_format: Optional[AudioFormat] = None
-
+    input_audio_noise_reduction: Optional[NoiseReduction] = None
 
 class ResponseCreateMessage(ClientMessageBase):
     """
@@ -272,7 +272,7 @@ class Session(BaseModel):
     tool_choice: ToolChoice
     temperature: Temperature
     max_response_output_tokens: Optional[MaxTokensType]
-
+    input_audio_noise_reduction: Optional[NoiseReduction] = None
 
 class SessionCreatedMessage(ServerMessageBase):
     type: Literal["session.created"] = "session.created"


### PR DESCRIPTION
## Purpose

* Added support for **noise cancellation** via `input_audio_noise_reduction` in the session configuration payload.
* Implemented `RealtimeAudioInputAudioNoiseReductionSettings` with a `type` field that accepts:
  * `"near_field"` – optimized for close-talking microphones (e.g., headsets)
  * `"far_field"` – optimized for distant microphones (e.g., laptop, room mics)
* Integrated the setting within the `SessionUpdateMessage` structure to enable real-time noise reduction in transcription scenarios.
* Complements existing support for custom transcription models, prompt guidance, and language specification.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

### Get the code

```bash
git clone https://github.com/Azure-Samples/aoai-realtime-audio-sdk
cd aoai-realtime-audio-sdk
git checkout Add_Noise_Reduction
npm install
```

### Update test or dev config

In your client-side test (`client_test`) or runtime session code, use this updated `ServerMessageType`:

```ts
let configMessage: SessionUpdateMessage = {
  type: "session.update",
  session: {
    voice: "verse",
    instructions: instruction,
    input_audio_format: "pcm16",
    input_audio_transcription: {
      model: "whisper-1"
    },
    turn_detection: {
      threshold: 0.9,
      prefix_padding_ms: 500,
      silence_duration_ms: 1400,
      type: "server_vad",
      interrupt_response: true,
    },
    input_audio_noise_reduction: {
      type: "near_field"
    }
  }
};
```

### Test the behavior

* Observe improved transcription accuracy in noisy environments
* Try both `near_field` and `far_field` settings in different mic setups
* Validate the presence of the `input_audio_noise_reduction` key in the outbound WebSocket payload

## What to Check

* `input_audio_noise_reduction` is included and structured correctly in the `ServerMessageType`
* The `type` field only accepts valid values (`near_field`, `far_field`)
* Backward compatibility: sessions work as expected when noise reduction is omitted
* Noise reduction configuration is applied before the audio stream begins
* No impact to other fields like `turn_detection` or `input_audio_transcription`

## Note:
Similarly do it for Python

## Other Information

* This addition follows the latest Microsoft Azure OpenAI real-time audio spec:
  [[Realtime Audio Reference – Noise Reduction](https://learn.microsoft.com/en-us/azure/ai-services/openai/realtime-audio-reference#inputaudionoisereduction)](https://learn.microsoft.com/en-us/azure/ai-services/openai/realtime-audio-reference#inputaudionoisereduction)
* Developers can now deliver a higher-quality transcription experience in environments with background noise.